### PR TITLE
SKA base box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,6 @@
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/bionic64"
+    config.vm.box = "ska-telescope/ska-base-box"
+    config.vm.box_version = "1.0.0"
     config.vm.synced_folder ".", "/vagrant"
     config.vm.provider "virtualbox" do |v|
        v.gui = true


### PR DESCRIPTION
This pull request changes only the Vagrantfile. 

The new base box used with virtualbox is set to be the ska-base-box that can be found on [vagrant cloud](https://app.vagrantup.com/ska-telescope/boxes/ska-base-box/versions/1.0.0) . 
A **ska-telescope** organisation has been created on vagrant cloud and a new image has been pushed as the default virtualbox ska base image.

Before merging testing is needed. 

One problem I am experiencing is a really slow donwload performance, this was not happening for other images hosted on the same platform. 

