### PR TITLE
ST-224 Migrate the CI pipelines from Debian Stretch to Debian Buster

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ stages:
   - build
   - trigger
 
-test_ubuntu_latest:
+test_ubuntu_18:
   image: ubuntu:18.04
   stage: build
   tags:
@@ -16,7 +16,6 @@ test_ubuntu_latest:
   - apt-add-repository --yes --update ppa:ansible/ansible 
   - apt-get -y install ansible
   - ansible-playbook -i hosts deploy_tangoenv.yml --extra-vars "install_ska_docker='no' start_tango='no' install_ide='no'"
-  
   
 test_ubuntu_16:
   image: ubuntu:16.04
@@ -32,10 +31,27 @@ test_ubuntu_16:
   - apt-add-repository --yes --update ppa:ansible/ansible 
   - apt-get -y install ansible
   - ansible-playbook -i hosts deploy_tangoenv.yml --extra-vars "install_ska_docker='no' start_tango='no' install_ide='no'"
-  
-  
+
 test_debian_stretch-slim:
   image: debian:stretch-slim
+  stage: build
+  tags:
+  - docker-executor
+  before_script:
+  - export TERM=linux
+  - export DEBIAN_FRONTEND=noninteractive
+  - apt-get update
+  - apt-get install -y bash python apt-transport-https ca-certificates curl software-properties-common python-apt
+  script:
+  - echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" >> /etc/apt/sources.list
+  - apt-get install gnupg2 -y
+  - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367
+  - apt-get update
+  - apt-get -y install ansible
+  - ansible-playbook -i hosts deploy_tangoenv.yml --extra-vars "install_ska_docker='no' start_tango='no' install_ide='no'"
+
+test_debian_buster-slim:
+  image: debian:buster-slim
   stage: build
   tags:
   - docker-executor

--- a/roles/mysqlserver/tasks/main.yml
+++ b/roles/mysqlserver/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
-
-- name: Install python python-dev python-pkgconfig python3-pymysql mysql-server mysql-client python-mysqldb
+- name: Install python python-dev python-pkgconfig python3-pymysql mysql-server mysql-client python-mysqldb (Ubuntu 16.04) (WARNING package names are deprecated on modern distros)
   apt:
     name:
         - python
@@ -13,20 +12,12 @@
     state: latest
     force: yes 
     update_cache: yes
-  when: install_mysql == 'yes'
-
-- name: install libmysqlclient-dev (Debian)
-  apt:
-    name:
-        - default-libmysqlclient-dev
-    state: latest
-    force: yes 
-    update_cache: yes
   when: 
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_version == '16.04'
     - install_mysql == 'yes'
 
-- name: install libmysqlclient-dev (Ubuntu)
+- name: install libmysqlclient-dev (Ubuntu 16.04) (WARNING package names are deprecated on modern distros)
   apt:
     name:
         - libmysqlclient-dev
@@ -35,6 +26,35 @@
     update_cache: yes
   when: 
     - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_version == '16.04'
+    - install_mysql == 'yes'
+
+- name: Install python python-dev python-pkgconfig python3-pymysql default-mysql-server default-mysql-client python-mysqldb
+  apt:
+    name:
+        - python
+        - python-dev 
+        - python-pkgconfig
+        - python3-pymysql
+        - default-mysql-server
+        - default-mysql-client
+        - python-mysqldb
+    state: latest
+    force: yes 
+    update_cache: yes
+  when:
+    - ansible_distribution_version != '16.04'
+    - install_mysql == 'yes'
+
+- name: install default-libmysqlclient-dev
+  apt:
+    name:
+        - default-libmysqlclient-dev
+    state: latest
+    force: yes 
+    update_cache: yes
+  when: 
+    - ansible_distribution_version != '16.04'
     - install_mysql == 'yes'
 
 - name: copy .my.cnf

--- a/roles/mysqlserver/tasks/main.yml
+++ b/roles/mysqlserver/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Install python python-dev python-pkgconfig python3-pymysql mysql-server mysql-client python-mysqldb (Ubuntu 16.04) (WARNING package names are deprecated on modern distros)
   apt:
     name:

--- a/roles/pytango/tasks/main.yml
+++ b/roles/pytango/tasks/main.yml
@@ -55,4 +55,26 @@
     virtualenv -p /usr/bin/python3 /venv
     pip3 install pipenv
     pipenv install --dev
-  when: install_pytango == 'yes'
+  when: 
+    - ansible_distribution_release != "buster"
+    - install_pytango == 'yes'
+
+- name: Install pytango on virtualenv with pipenv
+  shell: |
+    cd /build_pytango_dir
+    export LC_ALL=C.UTF-8 \
+      LANG=C.UTF-8 \
+      PIPENV_TIMEOUT=900 \
+      PATH=/venv/bin:$PATH \
+      VIRTUAL_ENV=/venv \
+      PIPENV_VERBOSITY=-1 \
+      PIPENV_NOSPIN=1
+    rm -r -f /venv
+    pwd
+    virtualenv -p /usr/bin/python3 /venv
+    pip3 install pipenv
+    ln -s /usr/lib/x86_64-linux-gnu/libboost_python3-py37.so /usr/lib/x86_64-linux-gnu/libboost_python-py37.so
+    pipenv install --dev
+  when: 
+    - ansible_distribution_release == "buster"
+    - install_pytango == 'yes'

--- a/roles/pytango/tasks/main.yml
+++ b/roles/pytango/tasks/main.yml
@@ -40,7 +40,7 @@
     force: yes
   when: install_pytango == 'yes'
 
-- name: Install pytango on virtualenv with pipenv
+- name: Install pytango on virtualenv with pipenv (Python 3.6)
   shell: |
     cd /build_pytango_dir
     export LC_ALL=C.UTF-8 \
@@ -59,7 +59,7 @@
     - ansible_distribution_release != "buster"
     - install_pytango == 'yes'
 
-- name: Install pytango on virtualenv with pipenv
+- name: Install pytango on virtualenv with pipenv (Python 3.7)
   shell: |
     cd /build_pytango_dir
     export LC_ALL=C.UTF-8 \

--- a/roles/tango/tasks/main.yml
+++ b/roles/tango/tasks/main.yml
@@ -20,7 +20,7 @@
     - build_tango == 'yes'
     - ansible_distribution == 'Ubuntu'
 
-- name: Install dependencies Ubuntu
+- name: Install dependencies Debian
   apt:
     name:
         - default-jdk


### PR DESCRIPTION
This pull request main focus was on adding Debian Buster testing to this repository.

Besides that, it fixes package naming for the mysql (which is actually MariaDB on modern distros) installation. A special case had to be added for *Ubuntu 16.04* since it doesn't conform to modern standards in this regard: **Consider deprecating Ubuntu 16.04 in the very near future.**

Unlike the other distros we are using, Debian Buster runs Python 3.7. This needed a special symbolic link to be created just for that scenario while installing *pytango*.

The usage of *pyenv* in order to standardize on a specific python version would be the future scenario to adopt. But that will need for the python boost package to be built from source instead of installing it from the distro repositories, since it depends on a specific python version to work (which doesn't accompany the *pyenv* version necessarily).